### PR TITLE
Add backup and restore functionality as discussed in Cloud Seminar #15 2023

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,15 @@
+FROM mariadb:10.5.12
+
+ENV MYSQL_ROOT_PASSWORD=secret
+ENV MYSQL_USER=username
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=wordpress
+
+COPY backup.sh /usr/local/bin/backup.sh
+COPY restore.sh /usr/local/bin/restore.sh
+
+RUN chmod +x /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/restore.sh
+RUN /usr/local/bin/restore.sh
+
+RUN echo "0 2 * * * /usr/local/bin/backup.sh" | crontab -

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -7,9 +7,12 @@ ENV MYSQL_DATABASE=wordpress
 
 COPY backup.sh /usr/local/bin/backup.sh
 COPY restore.sh /usr/local/bin/restore.sh
+COPY bro.cnf /home
+
+# Install cron
+RUN apt-get update && apt-get install -y cron
 
 RUN chmod +x /usr/local/bin/backup.sh
 RUN chmod +x /usr/local/bin/restore.sh
-RUN /usr/local/bin/restore.sh
 
 RUN echo "0 2 * * * /usr/local/bin/backup.sh" | crontab -

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -5,14 +5,15 @@ ENV MYSQL_USER=username
 ENV MYSQL_PASSWORD=password
 ENV MYSQL_DATABASE=wordpress
 
-COPY backup.sh /usr/local/bin/backup.sh
+COPY dump.sh /usr/local/bin/dump.sh
 COPY restore.sh /usr/local/bin/restore.sh
 COPY bro.cnf /home
 
 # Install cron
 RUN apt-get update && apt-get install -y cron
 
-RUN chmod +x /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/dump.sh
 RUN chmod +x /usr/local/bin/restore.sh
 
-RUN echo "0 2 * * * /usr/local/bin/backup.sh" | crontab -
+RUN echo "0 2 * * * /usr/local/bin/dump.sh" | crontab -
+RUN echo "30 3 * * 6 /usr/local/bin/backup.sh" | crontab -

--- a/db/backup.sh
+++ b/db/backup.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Define variables
-DB_NAME="wordpress"
-
-# Set the current date for the dump file
-DATE=$(date +"%Y%m%d_%H%M%S")
-DUMP_FILE="/etc/mysql/conf.d/backup/${DB_NAME}_backup_$DATE.sql"
-
 # Run mysqlbackup command
 mariabackup --defaults-extra-file=/home/bro.cnf \
    --backup \

--- a/db/backup.sh
+++ b/db/backup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Define variables
+DB_USER="username"
+DB_NAME="wordpress"
+
+# Set the current date for the backup file
+DATE=$(date +"%Y%m%d_%H%M%S")
+BACKUP_FILE="/etc/mysql/conf.d/backups/${DB_NAME}_backup_$DATE.sql"
+
+# Run mysqldump command
+mysqldump --defaults-extra-file=/etc/mysql/conf.d/custom-my.cnf "$DB_NAME" > "$BACKUP_FILE"

--- a/db/backup.sh
+++ b/db/backup.sh
@@ -3,9 +3,11 @@
 # Define variables
 DB_NAME="wordpress"
 
-# Set the current date for the backup file
+# Set the current date for the dump file
 DATE=$(date +"%Y%m%d_%H%M%S")
-BACKUP_FILE="/etc/mysql/conf.d/backups/${DB_NAME}_backup_$DATE.sql"
+DUMP_FILE="/etc/mysql/conf.d/backup/${DB_NAME}_backup_$DATE.sql"
 
-# Run mysqldump command
-mysqldump --defaults-extra-file=/home/bro.cnf "$DB_NAME" > "$BACKUP_FILE"
+# Run mysqlbackup command
+mariabackup --defaults-extra-file=/home/bro.cnf \
+   --backup \
+   --target-dir=/etc/mysql/conf.d/backup/

--- a/db/backup.sh
+++ b/db/backup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Define variables
-DB_USER="username"
 DB_NAME="wordpress"
 
 # Set the current date for the backup file
@@ -9,4 +8,4 @@ DATE=$(date +"%Y%m%d_%H%M%S")
 BACKUP_FILE="/etc/mysql/conf.d/backups/${DB_NAME}_backup_$DATE.sql"
 
 # Run mysqldump command
-mysqldump --defaults-extra-file=/etc/mysql/conf.d/custom-my.cnf "$DB_NAME" > "$BACKUP_FILE"
+mysqldump --defaults-extra-file=/home/bro.cnf "$DB_NAME" > "$BACKUP_FILE"

--- a/db/bro.cnf
+++ b/db/bro.cnf
@@ -5,3 +5,7 @@ password=password
 [mysql]             # NEEDED FOR RESTORE
 user=username
 password=password
+
+[mariabackup]
+user=root
+password=secret

--- a/db/bro.cnf
+++ b/db/bro.cnf
@@ -1,3 +1,7 @@
-[mysqldump]
-user=django
+[mysqldump]             # NEEDED FOR DUMP
+user=username
+password=password
+
+[mysql]             # NEEDED FOR RESTORE
+user=username
 password=password

--- a/db/bro.cnf
+++ b/db/bro.cnf
@@ -1,0 +1,3 @@
+[mysqldump]
+user=django
+password=password

--- a/db/dump.sh
+++ b/db/dump.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Define variables
+DB_NAME="wordpress"
+
+# Set the current date for the dump file
+DATE=$(date +"%Y%m%d_%H%M%S")
+DUMP_FILE="/etc/mysql/conf.d/dumps/${DB_NAME}_dump_$DATE.sql"
+
+# Run mysqldump command
+mysqldump --defaults-extra-file=/home/bro.cnf "$DB_NAME" > "$DUMP_FILE"

--- a/db/restore.sh
+++ b/db/restore.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-directory="/etc/mysql/conf.d/backups"
+backup=$(ls -t1 /etc/mysql/conf.d/backups | head -n 1)
 
-if [ -z "$(ls -A "$directory")" ]; then
+if [ -z ${backup} ]; then
     echo "No Backups found!"
 else
-    mysql --defaults-extra-file=/etc/mysql/conf.d/custom-my.cnf wordpress < $(ls -t1 /etc/mysql/conf.d/backups | head -n 1)
+    mysql --defaults-extra-file=/home/bro.cnf wordpress < /etc/mysql/conf.d/backups/${backup}
 fi

--- a/db/restore.sh
+++ b/db/restore.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+directory="/etc/mysql/conf.d/backups"
+
+if [ -z "$(ls -A "$directory")" ]; then
+    echo "No Backups found!"
+else
+    mysql --defaults-extra-file=/etc/mysql/conf.d/custom-my.cnf wordpress < $(ls -t1 /etc/mysql/conf.d/backups | head -n 1)
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,3 +3,24 @@
 # and compose your stack by running
 # docker compose up -d
 ################################################################################
+
+version: "2"
+services:
+  data:
+    build: data
+
+  db:
+    build: db
+    volumes_from:
+      - data
+    volumes:
+      - ~/dockerfiles/etc/mysql/conf.d:/etc/mysql/conf.d
+
+  wp:
+    image: wordpress:5.8.1-php8.0-apache
+    ports:
+      - "80:80"
+    links:
+      - db:mysql
+    volumes:
+      - ~/dockerfiles/wp-content:/var/www/html/wp-content

--- a/docker-compose.yml-cron-backup
+++ b/docker-compose.yml-cron-backup
@@ -1,0 +1,20 @@
+version: "2"
+services:
+  data:
+    build: data
+
+  db:
+    build: db
+    volumes_from:
+      - data
+    volumes:
+      - ~/dockerfiles/etc/mysql/conf.d:/etc/mysql/conf.d
+
+  wp:
+    image: wordpress:5.8.1-php8.0-apache
+    ports:
+      - "80:80"
+    links:
+      - db:mysql
+    volumes:
+      - ~/dockerfiles/wp-content:/var/www/html/wp-content


### PR DESCRIPTION
New compose file `docker-compose.yml-cron-backup` added.

To test the changes -

- copy the contents of `docker-compose.yml-cron-backup` to `docker-compose.yml`
- run `docker compose up`
- go to the wp site, install wp and create a blog post.
- now run the following command `docker exec -it <db-container-name> /usr/local/bin/backup.sh`
- bring down the containers `docker compose down`
- `sudo rm -rf wp-content`
- now run the following command `docker exec -it <db-container-name> /usr/local/bin/restore.sh`
- now when you go to the wp page you will see that the data has been restored.

Further -
- find a way to run restore.sh everytime the container starts.